### PR TITLE
fix crash between when trying to animate different instances of the same screen

### DIFF
--- a/src/SharedElement.js
+++ b/src/SharedElement.js
@@ -20,7 +20,7 @@ const contextTypes = {
   moveSharedElement: PropTypes.func.isRequired,
 };
 
-const elements = {};
+export const elements = {};
 // Test if the shred element is destination or source
 const isDestination = props => !!props.sourceId;
 // Destination element has id as a sourceId and source element has an id as an

--- a/src/SharedElementRenderer.js
+++ b/src/SharedElementRenderer.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import { Animated, View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
+import { elements } from './SharedElement';
+
 const childContextTypes = {
   moveSharedElement: PropTypes.func.isRequired,
 };
@@ -16,6 +18,12 @@ class SharedElementRenderer extends PureComponent {
     this.state = {
       config: null,
     };
+
+    // clean cached elements between instances of SharedElementRenderer as it is crashing
+    // when the SharedElement is rendered within a FlatList and the SharedElement was
+    // already animated once, probably due to trying to get the reference of a component
+    // that does not exists anymore
+    Object.keys(elements).forEach(key => delete elements[key]);
   }
   getChildContext() {
     return {


### PR DESCRIPTION
clean cached elements between instances of SharedElementRenderer as it is crashing
when the SharedElement is rendered within a FlatList and the SharedElement was
already animated once, probably due to trying to get the reference of a component
that does not exists anymore